### PR TITLE
إستخدام ملف الترويسة cmath بدلًا من math.h لإصلاح مشكلة #2

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <math.h>
+#include <cmath>
 
 int main() {
 	int number = 10;


### PR DESCRIPTION
استبدلت ملف الترويسة `math.h` في ملف `Alif5.cpp` إلى `cmath` لنجنب صراعات الأسماء وعدم ترجمة المشروع في بعض المترجمات.

لمعرفة المزيد، شرحت الموضوع في القضية #2.